### PR TITLE
[FEATURE] OAS 설정 및 api docs 위한 샘플 코드 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+/src/main/resources/static/swagger-ui/openapi3.yaml
+/build/api-spec/

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.3'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'com.epages.restdocs-api-spec' version '0.18.2'
 }
 
 group = 'com.daramg'
@@ -9,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(22)
 	}
 }
 
@@ -35,8 +36,38 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.18.2'
+	testImplementation 'com.epages:restdocs-api-spec-restassured:0.18.2'
+	testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
+	//implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+openapi3{
+	server = 'http://localhost:8080'
+	//server = 추가
+	title = "Pickup Daramg's API docs"
+	description = '픽업하는 다람쥐의 API 문서입니다.'
+	version = '0.1.0'
+	format = 'yaml'
+}
+
+tasks.register('copyOasToSwagger', Copy) {
+	// 기존 yaml 파일 삭제
+	delete 'src/main/resources/static/swagger-ui/openapi3.yaml'
+
+	// 복제할 yaml 파일 타겟팅
+	from "build/api-spec/openapi3.yaml"
+
+	// 타겟 디렉토리로 파일 복제
+	into 'src/main/resources/static/swagger-ui'
+
+	//test가 먼저 실행되도록 설정
+	dependsOn tasks.named('test')
+
+	// openapi3 task가 먼저 실행되도록 설정
+	dependsOn tasks.named('openapi3')
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  backend:
+    build:
+      context: ./
+    ports:
+      - "8080:8080"
+    container_name: spring-app
+
+  swagger:
+    build:
+      context: ./src/main/resources/static/swagger-ui
+    ports:
+      - "8081:80"
+    container_name: swagger-ui

--- a/src/main/java/com/daramg/pickup_service/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/daramg/pickup_service/common/exception/GlobalExceptionHandler.java
@@ -32,17 +32,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .body(ErrorResponse.of(HttpStatus.BAD_REQUEST, errorMessage, request.getRequestURI()));
     }
 
-//    @ExceptionHandler(MethodArgumentNotValidException.class)
-//    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpServletRequest request) {
-//        String errorMessage = ex.getBindingResult().getAllErrors().stream()
-//                .map(DefaultMessageSourceResolvable::getDefaultMessage)
-//                .collect(Collectors.joining(", "));
-//
-//        return ResponseEntity
-//                .status(HttpStatus.BAD_REQUEST)
-//                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST, errorMessage, request.getRequestURI()));
-//    }
-
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex, HttpServletRequest request) {
         return ResponseEntity

--- a/src/main/java/com/daramg/pickup_service/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/daramg/pickup_service/common/exception/GlobalExceptionHandler.java
@@ -3,12 +3,9 @@ package com.daramg.pickup_service.common.exception;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
@@ -17,7 +14,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
-@RestControllerAdvice(annotations = {RestController.class})
+@RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private static final String BAD_REQUEST_DEFAULT_MESSAGE = "잘못된 요청입니다.";
@@ -35,16 +32,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .body(ErrorResponse.of(HttpStatus.BAD_REQUEST, errorMessage, request.getRequestURI()));
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpServletRequest request) {
-        String errorMessage = ex.getBindingResult().getAllErrors().stream()
-                .map(DefaultMessageSourceResolvable::getDefaultMessage)
-                .collect(Collectors.joining(", "));
-
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST, errorMessage, request.getRequestURI()));
-    }
+//    @ExceptionHandler(MethodArgumentNotValidException.class)
+//    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpServletRequest request) {
+//        String errorMessage = ex.getBindingResult().getAllErrors().stream()
+//                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+//                .collect(Collectors.joining(", "));
+//
+//        return ResponseEntity
+//                .status(HttpStatus.BAD_REQUEST)
+//                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST, errorMessage, request.getRequestURI()));
+//    }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex, HttpServletRequest request) {

--- a/src/main/java/com/daramg/pickup_service/infrastructure/config/ApiDocsResourceConfig.java
+++ b/src/main/java/com/daramg/pickup_service/infrastructure/config/ApiDocsResourceConfig.java
@@ -1,0 +1,18 @@
+package com.daramg.pickup_service.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class ApiDocsResourceConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/swagger-ui.html")
+                .addResourceLocations("classpath:/static/swagger-ui/");
+
+        registry.addResourceHandler("/swagger-ui/**")
+                .addResourceLocations("classpath:/static/swagger-ui/");
+    }
+}

--- a/src/main/java/com/daramg/pickup_service/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/daramg/pickup_service/infrastructure/config/SecurityConfig.java
@@ -15,9 +15,9 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll() // ✅ 모든 요청 허용
+                        .anyRequest().permitAll()
                 )
-                .csrf(AbstractHttpConfigurer::disable); // Rest API 테스트 시 CSRF도 비활성화
+                .csrf(AbstractHttpConfigurer::disable);
 
         return http.build();
     }

--- a/src/main/java/com/daramg/pickup_service/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/daramg/pickup_service/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,24 @@
+package com.daramg.pickup_service.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll() // ✅ 모든 요청 허용
+                )
+                .csrf(AbstractHttpConfigurer::disable); // Rest API 테스트 시 CSRF도 비활성화
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/daramg/pickup_service/presentation/SampleController.java
+++ b/src/main/java/com/daramg/pickup_service/presentation/SampleController.java
@@ -1,0 +1,15 @@
+package com.daramg.pickup_service.presentation;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/sample")
+@RestController
+public class SampleController {
+
+    @GetMapping
+    public String getSampleMessage(){
+        return "람쥐~";
+    }
+}

--- a/src/main/resources/static/swagger-ui/Dockerfile
+++ b/src/main/resources/static/swagger-ui/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+COPY . /usr/share/nginx/html
+EXPOSE 80

--- a/src/test/java/com/daramg/pickup_service/presentation/SampleControllerTest.java
+++ b/src/test/java/com/daramg/pickup_service/presentation/SampleControllerTest.java
@@ -1,0 +1,59 @@
+package com.daramg.pickup_service.presentation;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper;
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
+
+@DisplayName("SampleController 테스트")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(RestDocumentationExtension.class)
+public class SampleControllerTest {
+
+    protected RequestSpecification spec;
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        RestAssured.port = port;
+        this.spec = new RequestSpecBuilder()
+                .addFilter(documentationConfiguration(restDocumentation))
+                .build();
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("/sample GET 요청 시 '람쥐~' 반환")
+    void getSampleMessage() {
+        given(spec)
+                .filter(RestAssuredRestDocumentationWrapper.document("sample-get",
+                        ResourceSnippetParameters.builder()
+                                .tag("Sample")
+                                .summary("람쥐 메시지 반환")
+                                .description("GET /sample 요청 시 '람쥐~' 문자열을 반환합니다.")
+                ))
+                .accept("*/*")
+                .when()
+                .get("/sample")
+                .then()
+                .statusCode(200)
+                .body(equalTo("람쥐~"));
+    }
+
+}


### PR DESCRIPTION
- swagger와 restdocs 결합 방식의 OAS api 문서화 설정
- docker 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * /sample 엔드포인트가 추가되어 "람쥐~"라는 텍스트 응답을 제공합니다.
  * Swagger UI 정적 리소스 제공 및 OpenAPI 문서 자동 생성이 지원됩니다.
  * Docker Compose를 통해 백엔드와 Swagger UI를 각각 컨테이너로 실행할 수 있습니다.

* **버그 수정**
  * 전역 예외 처리기에서 유효성 검증 실패 예외 처리 메서드가 제거되었습니다.

* **문서화**
  * /sample 엔드포인트에 대한 API 문서화 테스트가 추가되었습니다.

* **환경설정/작업**
  * Java 22 버전으로 빌드 환경이 업데이트되었습니다.
  * 보안 설정이 추가되어 모든 요청이 인증 없이 허용됩니다.
  * .gitignore 규칙이 일부 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->